### PR TITLE
Add Generate Rhymes API (POST /story/generate-rhyme) #21

### DIFF
--- a/routers/story.py
+++ b/routers/story.py
@@ -6,13 +6,16 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from schemas.story import (
+    StoryGenerateRequest,
+    StoryGenerateResponse,
     StoryRewriteRequest,
     StoryRewriteResponse,
-    ErrorResponse
+    ErrorResponse,
 )
 from utils.huggingface_client import (
     HuggingFaceError,
     rewrite_story,
+    generate_rhyme,
 )
 from utils.safety_filter import clean_text_for_model, extract_child_name, is_content_safe
 from utils.auth_service import get_current_user
@@ -22,6 +25,61 @@ from utils.story_history_service import save_story_record
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.post("/generate-rhyme", response_model=StoryGenerateResponse)
+def generate_rhyme_endpoint(
+    request: StoryGenerateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+):
+    """
+    Generate a short rhyme/nursery rhyme for a child. Reuses StoryGenerateRequest schema.
+    """
+    # Validate age
+    if request.age < 1 or request.age > 10:
+        raise HTTPException(status_code=400, detail="Age must be between 1 and 10")
+
+    cleaned_prompt = clean_text_for_model(request.prompt)
+    if not cleaned_prompt:
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+
+    if not is_content_safe(cleaned_prompt):
+        raise HTTPException(status_code=400, detail="Prompt contains unsafe content and cannot be processed.")
+
+    child_name = extract_child_name(cleaned_prompt)
+    if child_name is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Child name is required in the prompt. Please include at least one child name, e.g. 'for Emma, age 4'."
+            ),
+        )
+
+    try:
+        rhyme_text = generate_rhyme(cleaned_prompt, request.age)
+
+        if not is_content_safe(rhyme_text):
+            return StoryGenerateResponse(story="I'm sorry, but the generated rhyme contains inappropriate content for children.")
+
+        try:
+            save_story_record(
+                user_id=current_user.user_id,
+                child_name=child_name,
+                prompt=cleaned_prompt,
+                story=rhyme_text,
+                age=request.age,
+                mode=current_user.mode,
+                record_type="generate",
+            )
+        except ValueError as exc:
+            logger.warning("Story history validation failed: %s", str(exc))
+
+        return StoryGenerateResponse(story=rhyme_text)
+
+    except HuggingFaceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=f"Rhyme generation failed: {str(exc)}")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Rhyme generation failed: {str(exc)}")
 
 
 @router.post("/rewrite", response_model=StoryRewriteResponse)

--- a/utils/huggingface_client.py
+++ b/utils/huggingface_client.py
@@ -270,6 +270,44 @@ def sample_completion(prompt: str) -> str:
     return _call_huggingface_api(messages, max_length=800)
 
 
+def generate_rhyme(prompt: str, age: int) -> str:
+    """
+    Generate a short rhyme or nursery rhyme based on user prompt and age.
+
+    Args:
+        prompt: User's rhyme prompt (free-form)
+        age: Child's age (1-18)
+
+    Returns:
+        Generated rhyme text
+    """
+    # Build age-appropriate system instruction using existing guidance
+    age_guidance = _get_age_guidance(age)
+
+    system_msg = (
+        "You are a creative children's poet. "
+        f"{age_guidance}"
+    )
+    user_msg = (
+        "Rhyme request: "
+        f"{prompt}\n\n"
+        "Write a short, rhyming poem or nursery rhyme based on this request. "
+        "Use simple vocabulary and short lines suitable for the target age. "
+        "Keep the rhyme playful and end with a clear, positive ending. "
+        "If a child's name is included in the prompt, incorporate it naturally into the rhyme."
+    )
+
+    messages = [
+        {"role": "system", "content": system_msg},
+        {"role": "user", "content": user_msg},
+    ]
+
+    # Call Hugging Face API (OpenAI-compatible)
+    rhyme = _call_huggingface_api(messages, max_length=1200)
+
+    return rhyme
+
+
 def _get_age_guidance(age: int) -> str:
     """
     Get age-appropriate guidance for story generation.


### PR DESCRIPTION
## Overview

Adds backend support for generating short rhymes via Hugging Face and exposes a new endpoint for frontend use.

The implementation reuses the same validation, safety filtering, and history-saving logic already used in story generation and rewrite flows.

## Endpoint

POST /story/generate-rhyme

Generates a short rhyme/nursery rhyme for a child.

The endpoint reuses the existing request/response schema:
StoryGenerateRequest / StoryGenerateResponse.

## Implementation Details

### Helper
utils/huggingface_client.py

Added:

generate_rhyme(prompt: str, age: int)

This helper:
- Applies the same age guidance logic
- Sends the request to the Hugging Face client
- Returns generated rhyme text

### Router
routers/story.py

Added endpoint:

POST /story/generate-rhyme

This endpoint:

- Validates age (must be between 1 and 10)
- Validates non-empty prompt
- Runs prompt cleaning via clean_text_for_model()
- Runs safety filtering via is_content_safe()
- Extracts child name using extract_child_name()
- Calls generate_rhyme() helper
- Saves result using save_story_record(..., record_type="generate")
- Returns StoryGenerateResponse

Authentication and error handling follow the same pattern used in existing story endpoints.

Closes #21
