### PR TITLE
JJ #11 Add backend TTS support with optional include_tts flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Create a file named `.env` in the project root with the following content:
 HUGGINGFACE_API_TOKEN=hf_your_token_here
 HUGGINGFACE_API_URL=https://router.huggingface.co/v1/chat/completions
 HUGGINGFACE_MODEL=mistralai/Mistral-7B-Instruct-v0.2
+HUGGINGFACE_TTS_MODEL=espnet/kan-bayashi_ljspeech_vits
+HUGGINGFACE_TTS_API_URL=https://api-inference.huggingface.co/models/{model}
 
 KIDDOLAND_AUTH_SECRET=change_me
 KIDDOLAND_AUTH_TTL_SECONDS=3600
@@ -110,7 +112,7 @@ MONGODB_DB_NAME=kiddoland
 MONGODB_USERS_COLLECTION=users
 ```
 
-Replace `hf_your_token_here` with your actual Hugging Face token from step 2. The `KIDDOLAND_AUTH_USERS` value is optional; if omitted, demo users are created at runtime.
+Replace `hf_your_token_here` with your actual Hugging Face token from step 2. The `KIDDOLAND_AUTH_USERS` value is optional; if omitted, demo users are created at runtime. The TTS variables are optional; defaults are used if not set.
 
 ### 5. Run the Server
 
@@ -224,6 +226,36 @@ POST /story/rewrite
   "instruction": "Change the middle part to make it funnier"
 }
 ```
+
+### 4. Sample AI (Optional TTS on Existing Endpoint)
+
+```
+POST /ai/sample
+```
+
+**Request Body:**
+
+```json
+{
+  "prompt": "Say hello to a curious 7-year-old who loves space.",
+  "include_tts": true
+}
+```
+
+**Response:**
+
+```json
+{
+  "output": "Hi there, space explorer! Ready to zoom past the stars today?",
+  "tts_audio_base64": "UklGRhQAAABXQVZFZm10IBAAAAABAAEA...",
+  "tts_media_type": "audio/mpeg"
+}
+```
+
+Notes:
+- `include_tts` defaults to `false`.
+- Existing frontend calls that only send `prompt` continue to work unchanged.
+- When `include_tts=false`, `tts_audio_base64` and `tts_media_type` are `null`.
 
 **Response:**
 

--- a/routers/ai.py
+++ b/routers/ai.py
@@ -1,6 +1,7 @@
 
 import logging
 import re
+import base64
 from typing import Optional, List
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -34,7 +35,7 @@ from schemas.ai import (
 )
 from schemas.auth import AuthUser
 from utils.auth_service import get_current_user
-from utils.huggingface_client import HuggingFaceError, sample_completion
+from utils.huggingface_client import HuggingFaceError, sample_completion, generate_tts_audio
 from utils.safety_filter import clean_text_for_model, extract_child_name, is_content_safe
 from utils.story_history_service import list_story_records, save_story_record, mark_story_favorite
 
@@ -136,6 +137,13 @@ def sample_ai_endpoint(
 
     try:
         output = sample_completion(cleaned_prompt)
+        tts_audio_base64 = None
+        tts_media_type = None
+        if request.include_tts:
+            audio_bytes, media_type = generate_tts_audio(output)
+            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+            tts_media_type = media_type
+
         try:
             save_story_record(
                 user_id=current_user.user_id,
@@ -149,7 +157,11 @@ def sample_ai_endpoint(
         except ValueError as exc:
             logger.warning("Auto-save story history validation failed: %s", str(exc))
 
-        return AiSampleResponse(output=output)
+        return AiSampleResponse(
+            output=output,
+            tts_audio_base64=tts_audio_base64,
+            tts_media_type=tts_media_type,
+        )
     except HuggingFaceError as exc:
         raise HTTPException(
             status_code=exc.status_code,

--- a/routers/story.py
+++ b/routers/story.py
@@ -2,6 +2,7 @@
 Story Router
 Handles story generation and rewriting endpoints
 """
+import base64
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -16,6 +17,7 @@ from utils.huggingface_client import (
     HuggingFaceError,
     rewrite_story,
     generate_rhyme,
+    generate_tts_audio,
 )
 from utils.safety_filter import clean_text_for_model, extract_child_name, is_content_safe
 from utils.auth_service import get_current_user
@@ -61,6 +63,13 @@ def generate_rhyme_endpoint(
         if not is_content_safe(rhyme_text):
             return StoryGenerateResponse(story="I'm sorry, but the generated rhyme contains inappropriate content for children.")
 
+        tts_audio_base64 = None
+        tts_media_type = None
+        if request.include_tts:
+            audio_bytes, media_type = generate_tts_audio(rhyme_text)
+            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+            tts_media_type = media_type
+
         try:
             save_story_record(
                 user_id=current_user.user_id,
@@ -74,7 +83,11 @@ def generate_rhyme_endpoint(
         except ValueError as exc:
             logger.warning("Story history validation failed: %s", str(exc))
 
-        return StoryGenerateResponse(story=rhyme_text)
+        return StoryGenerateResponse(
+            story=rhyme_text,
+            tts_audio_base64=tts_audio_base64,
+            tts_media_type=tts_media_type,
+        )
 
     except HuggingFaceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=f"Rhyme generation failed: {str(exc)}")
@@ -168,6 +181,13 @@ def rewrite_story_endpoint(
             return StoryRewriteResponse(
                 story="I'm sorry, but the rewritten story contains inappropriate content for children. Please try a different instruction."
             )
+
+        tts_audio_base64 = None
+        tts_media_type = None
+        if request.include_tts:
+            audio_bytes, media_type = generate_tts_audio(rewritten_story)
+            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+            tts_media_type = media_type
         
         try:
             save_story_record(
@@ -182,7 +202,11 @@ def rewrite_story_endpoint(
         except ValueError as exc:
             logger.warning("Story history validation failed: %s", str(exc))
 
-        return StoryRewriteResponse(story=rewritten_story)
+        return StoryRewriteResponse(
+            story=rewritten_story,
+            tts_audio_base64=tts_audio_base64,
+            tts_media_type=tts_media_type,
+        )
     
     except HuggingFaceError as exc:
         raise HTTPException(

--- a/schemas/ai.py
+++ b/schemas/ai.py
@@ -15,11 +15,16 @@ class AiSampleRequest(BaseModel):
         max_length=2000,
         description="Prompt for the sample AI response",
     )
+    include_tts: bool = Field(
+        default=False,
+        description="When true, also return TTS audio data for the generated output",
+    )
 
     class Config:
         json_schema_extra = {
             "example": {
                 "prompt": "Say hello to a curious 7-year-old who loves space.",
+                "include_tts": True,
             }
         }
 
@@ -30,11 +35,21 @@ class AiSampleResponse(BaseModel):
         ...,
         description="Generated response text",
     )
+    tts_audio_base64: str | None = Field(
+        default=None,
+        description="Base64-encoded audio payload when include_tts=true",
+    )
+    tts_media_type: str | None = Field(
+        default=None,
+        description="Media type of synthesized audio, for example audio/mpeg",
+    )
 
     class Config:
         json_schema_extra = {
             "example": {
-                "output": "Hi there, space explorer! Ready to zoom past the stars today?"
+                "output": "Hi there, space explorer! Ready to zoom past the stars today?",
+                "tts_audio_base64": "UklGRhQAAABXQVZFZm10IBAAAAABAAEA...",
+                "tts_media_type": "audio/mpeg",
             }
         }
 

--- a/schemas/story.py
+++ b/schemas/story.py
@@ -18,12 +18,17 @@ class StoryGenerateRequest(BaseModel):
         max_length=2000,
         description="Free-form story prompt"
     )
+    include_tts: bool = Field(
+        default=False,
+        description="When true, also return TTS audio data for the generated story"
+    )
     
     class Config:
         json_schema_extra = {
             "example": {
                 "age": 10,
-                "prompt": "Write a story about a shy dragon who learns to make friends"
+                "prompt": "Write a story about a shy dragon who learns to make friends",
+                "include_tts": True,
             }
         }
 
@@ -34,11 +39,21 @@ class StoryGenerateResponse(BaseModel):
         ...,
         description="Generated story text"
     )
+    tts_audio_base64: str | None = Field(
+        default=None,
+        description="Base64-encoded audio payload when include_tts=true"
+    )
+    tts_media_type: str | None = Field(
+        default=None,
+        description="Media type of synthesized audio, for example audio/mpeg"
+    )
     
     class Config:
         json_schema_extra = {
             "example": {
-                "story": "Once upon a time, there was a shy dragon named Ember..."
+                "story": "Once upon a time, there was a shy dragon named Ember...",
+                "tts_audio_base64": "UklGRhQAAABXQVZFZm10IBAAAAABAAEA...",
+                "tts_media_type": "audio/mpeg",
             }
         }
 
@@ -63,13 +78,18 @@ class StoryRewriteRequest(BaseModel):
         max_length=1000,
         description="Free-form rewrite instruction (e.g., 'make it happier', 'change the ending')"
     )
+    include_tts: bool = Field(
+        default=False,
+        description="When true, also return TTS audio data for the rewritten story"
+    )
     
     class Config:
         json_schema_extra = {
             "example": {
                 "age": 10,
                 "original_story": "Once upon a time, there was a shy dragon...",
-                "instruction": "Change the middle part to make it funnier"
+                "instruction": "Change the middle part to make it funnier",
+                "include_tts": True,
             }
         }
 
@@ -80,11 +100,21 @@ class StoryRewriteResponse(BaseModel):
         ...,
         description="Rewritten story text"
     )
+    tts_audio_base64: str | None = Field(
+        default=None,
+        description="Base64-encoded audio payload when include_tts=true"
+    )
+    tts_media_type: str | None = Field(
+        default=None,
+        description="Media type of synthesized audio, for example audio/mpeg"
+    )
     
     class Config:
         json_schema_extra = {
             "example": {
-                "story": "Once upon a time, there was a shy dragon who was terrified of sneezing..."
+                "story": "Once upon a time, there was a shy dragon who was terrified of sneezing...",
+                "tts_audio_base64": "UklGRhQAAABXQVZFZm10IBAAAAABAAEA...",
+                "tts_media_type": "audio/mpeg",
             }
         }
 

--- a/utils/huggingface_client.py
+++ b/utils/huggingface_client.py
@@ -5,7 +5,9 @@ Handles communication with Hugging Face Inference API
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+from typing import Tuple
 
 import requests
 
@@ -15,6 +17,9 @@ from utils.config import get_huggingface_config
 REQUEST_TIMEOUT = 60  # seconds
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TTS_MODEL = "espnet/kan-bayashi_ljspeech_vits"
+DEFAULT_TTS_API_URL_TEMPLATE = "https://api-inference.huggingface.co/models/{model}"
 
 
 @dataclass
@@ -306,6 +311,92 @@ def generate_rhyme(prompt: str, age: int) -> str:
     rhyme = _call_huggingface_api(messages, max_length=1200)
 
     return rhyme
+
+
+def generate_tts_audio(text: str) -> Tuple[bytes, str]:
+    """
+    Generate speech audio from plain text using Hugging Face Inference API.
+
+    Args:
+        text: Text to convert into speech
+
+    Returns:
+        Tuple (audio_bytes, media_type)
+    """
+    if not text or not text.strip():
+        raise HuggingFaceResponseError("TTS text cannot be empty")
+
+    try:
+        config = get_huggingface_config()
+    except RuntimeError as exc:
+        logger.error("Hugging Face config error: %s", exc)
+        raise HuggingFaceConfigError(
+            "Hugging Face is not configured on the server."
+        )
+
+    tts_model = os.getenv("HUGGINGFACE_TTS_MODEL", "").strip() or DEFAULT_TTS_MODEL
+    tts_url_template = os.getenv("HUGGINGFACE_TTS_API_URL", "").strip() or DEFAULT_TTS_API_URL_TEMPLATE
+    tts_url = tts_url_template.format(model=tts_model)
+
+    headers = {
+        "Authorization": f"Bearer {config.api_token}",
+        "Content-Type": "application/json",
+        "Accept": "audio/mpeg, audio/wav, audio/flac, audio/ogg, application/octet-stream",
+    }
+    payload = {"inputs": text.strip()}
+
+    try:
+        response = requests.post(
+            tts_url,
+            headers=headers,
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+
+        if response.status_code in {401, 403}:
+            logger.warning("Hugging Face TTS auth failed with status %s", response.status_code)
+            raise HuggingFaceAuthError("Hugging Face token is invalid or expired.")
+
+        if response.status_code == 503:
+            raise HuggingFaceResponseError(
+                "The TTS model is currently loading. Please try again in a few moments."
+            )
+
+        if response.status_code != 200:
+            error_detail = response.text.strip() or "Unknown error"
+            try:
+                parsed = response.json()
+                if isinstance(parsed, dict):
+                    error_detail = parsed.get("error") or parsed.get("message") or error_detail
+            except ValueError:
+                pass
+            raise HuggingFaceResponseError(f"Hugging Face TTS API error: {error_detail}")
+
+        media_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
+        if not media_type:
+            media_type = "application/octet-stream"
+
+        # Some hosted endpoints return octet-stream for binary audio; accept it.
+        if not (media_type.startswith("audio/") or media_type == "application/octet-stream"):
+            logger.warning("Unexpected TTS content-type: %s", media_type)
+            raise HuggingFaceResponseError(
+                "TTS endpoint returned a non-audio response."
+            )
+
+        if not response.content:
+            raise HuggingFaceResponseError("TTS endpoint returned empty audio data.")
+
+        return response.content, media_type
+
+    except requests.exceptions.Timeout:
+        raise HuggingFaceTimeoutError(
+            "Request to Hugging Face TTS API timed out. Please try again."
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Hugging Face TTS network error: %s", str(exc))
+        raise HuggingFaceNetworkError(
+            "Network error while calling Hugging Face TTS API. Please try again."
+        )
 
 
 def _get_age_guidance(age: int) -> str:


### PR DESCRIPTION
## Summary
This pull request adds optional Text-to-Speech (TTS) support to the backend using the Hugging Face inference API. The implementation allows clients to receive audio narration for generated text while maintaining full backward compatibility with existing API behavior.

## Key Changes
- Added optional `include_tts` request flag to enable TTS generation.
- Integrated Hugging Face TTS inference through a reusable helper function.
- Updated API response schemas to include optional audio fields:
  - `tts_audio_base64`
  - `tts_media_type`
- Ensured existing API responses remain unchanged when `include_tts` is not provided.
- **This feature is optional and will NOT break existing frontend API calls.**

## Affected Endpoints
The following endpoints now support optional TTS:

- `POST /ai/sample`
- `POST /story/generate-rhyme`
- `POST /story/rewrite`

Clients can request audio by including:

{
  "age": 10,
  "prompt": "Write a story about a shy dragon who learns to make friends",
  "include_tts": true
}

**Note**
- **`include_tts` is optional**
- **If it is not provided, the API behaves exactly the same as before**
- **Existing frontend UI requests will continue to work without any changes**

Closes #11