### PR TITLE
Backend: Stabilize Optional TTS for ai/sample, story/generate-rhyme, and story/rewrite (HF router compatibility + fallback)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.0
 pydantic==2.5.3
 requests==2.31.0
 pymongo==4.6.1
+gTTS==2.5.4

--- a/routers/ai.py
+++ b/routers/ai.py
@@ -140,9 +140,12 @@ def sample_ai_endpoint(
         tts_audio_base64 = None
         tts_media_type = None
         if request.include_tts:
-            audio_bytes, media_type = generate_tts_audio(output)
-            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
-            tts_media_type = media_type
+            try:
+                audio_bytes, media_type = generate_tts_audio(output)
+                tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+                tts_media_type = media_type
+            except HuggingFaceError as exc:
+                logger.warning("Optional TTS failed for /ai/sample: %s", str(exc))
 
         try:
             save_story_record(

--- a/routers/story.py
+++ b/routers/story.py
@@ -66,9 +66,12 @@ def generate_rhyme_endpoint(
         tts_audio_base64 = None
         tts_media_type = None
         if request.include_tts:
-            audio_bytes, media_type = generate_tts_audio(rhyme_text)
-            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
-            tts_media_type = media_type
+            try:
+                audio_bytes, media_type = generate_tts_audio(rhyme_text)
+                tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+                tts_media_type = media_type
+            except HuggingFaceError as exc:
+                logger.warning("Optional TTS failed for /story/generate-rhyme: %s", str(exc))
 
         try:
             save_story_record(
@@ -185,9 +188,12 @@ def rewrite_story_endpoint(
         tts_audio_base64 = None
         tts_media_type = None
         if request.include_tts:
-            audio_bytes, media_type = generate_tts_audio(rewritten_story)
-            tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
-            tts_media_type = media_type
+            try:
+                audio_bytes, media_type = generate_tts_audio(rewritten_story)
+                tts_audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+                tts_media_type = media_type
+            except HuggingFaceError as exc:
+                logger.warning("Optional TTS failed for /story/rewrite: %s", str(exc))
         
         try:
             save_story_record(

--- a/utils/huggingface_client.py
+++ b/utils/huggingface_client.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 import logging
 import os
+from io import BytesIO
 from dataclasses import dataclass
 from typing import Tuple
 
 import requests
+from gtts import gTTS
 
 from utils.config import get_huggingface_config
 
@@ -18,8 +20,21 @@ REQUEST_TIMEOUT = 60  # seconds
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TTS_MODEL = "espnet/kan-bayashi_ljspeech_vits"
-DEFAULT_TTS_API_URL_TEMPLATE = "https://api-inference.huggingface.co/models/{model}"
+DEFAULT_TTS_MODEL = "hexgrad/Kokoro-82M"
+DEFAULT_TTS_API_URL_TEMPLATE = "https://router.huggingface.co/hf-inference/models/{model}"
+
+
+def _normalize_tts_url_template(url_template: str) -> str:
+    normalized = url_template.strip()
+    if not normalized:
+        return DEFAULT_TTS_API_URL_TEMPLATE
+
+    deprecated_prefix = "https://api-inference.huggingface.co/models"
+    router_prefix = "https://router.huggingface.co/hf-inference/models"
+    if normalized.startswith(deprecated_prefix):
+        return normalized.replace(deprecated_prefix, router_prefix, 1)
+
+    return normalized
 
 
 @dataclass
@@ -335,7 +350,9 @@ def generate_tts_audio(text: str) -> Tuple[bytes, str]:
         )
 
     tts_model = os.getenv("HUGGINGFACE_TTS_MODEL", "").strip() or DEFAULT_TTS_MODEL
-    tts_url_template = os.getenv("HUGGINGFACE_TTS_API_URL", "").strip() or DEFAULT_TTS_API_URL_TEMPLATE
+    tts_url_template = _normalize_tts_url_template(
+        os.getenv("HUGGINGFACE_TTS_API_URL", "")
+    )
     tts_url = tts_url_template.format(model=tts_model)
 
     headers = {
@@ -353,15 +370,6 @@ def generate_tts_audio(text: str) -> Tuple[bytes, str]:
             timeout=REQUEST_TIMEOUT,
         )
 
-        if response.status_code in {401, 403}:
-            logger.warning("Hugging Face TTS auth failed with status %s", response.status_code)
-            raise HuggingFaceAuthError("Hugging Face token is invalid or expired.")
-
-        if response.status_code == 503:
-            raise HuggingFaceResponseError(
-                "The TTS model is currently loading. Please try again in a few moments."
-            )
-
         if response.status_code != 200:
             error_detail = response.text.strip() or "Unknown error"
             try:
@@ -370,7 +378,7 @@ def generate_tts_audio(text: str) -> Tuple[bytes, str]:
                     error_detail = parsed.get("error") or parsed.get("message") or error_detail
             except ValueError:
                 pass
-            raise HuggingFaceResponseError(f"Hugging Face TTS API error: {error_detail}")
+            return _generate_gtts_audio(text.strip(), error_detail)
 
         media_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
         if not media_type:
@@ -389,13 +397,28 @@ def generate_tts_audio(text: str) -> Tuple[bytes, str]:
         return response.content, media_type
 
     except requests.exceptions.Timeout:
-        raise HuggingFaceTimeoutError(
-            "Request to Hugging Face TTS API timed out. Please try again."
-        )
+        return _generate_gtts_audio(text.strip(), "Request to Hugging Face TTS API timed out")
     except requests.exceptions.RequestException as exc:
         logger.warning("Hugging Face TTS network error: %s", str(exc))
+        return _generate_gtts_audio(text.strip(), str(exc))
+
+
+def _generate_gtts_audio(text: str, original_error: str) -> Tuple[bytes, str]:
+    """
+    Fallback TTS using Google TTS when Hugging Face TTS is unavailable.
+    """
+    try:
+        logger.warning("Falling back to gTTS because Hugging Face TTS failed: %s", original_error)
+        buffer = BytesIO()
+        gTTS(text=text, lang="en").write_to_fp(buffer)
+        audio_bytes = buffer.getvalue()
+        if not audio_bytes:
+            raise HuggingFaceResponseError("Fallback TTS returned empty audio data.")
+        return audio_bytes, "audio/mpeg"
+    except Exception as exc:
+        logger.warning("Fallback gTTS failed: %s", str(exc))
         raise HuggingFaceNetworkError(
-            "Network error while calling Hugging Face TTS API. Please try again."
+            f"TTS is currently unavailable. Hugging Face error: {original_error}"
         )
 
 


### PR DESCRIPTION
This PR fixes and hardens optional Text-to-Speech behavior across the 3 story-generation APIs so text responses remain reliable while audio is returned whenever possible.

**Scope**
- POST /ai/sample
- POST /story/generate-rhyme
- POST /story/rewrite

**What was fixed**
- Added Hugging Face TTS router compatibility updates (new routing behavior/model handling).
- Implemented fallback TTS provider when HF TTS fails, so audio generation is more resilient.
- Kept TTS fully optional through include_tts flag without breaking existing clients.
- Applied fail-open behavior: if TTS fails, endpoint still returns successful text output.
- Standardized optional response fields for TTS payload:
  - tts_audio_base64
  - tts_media_type
- Updated backend dependencies and validated end-to-end behavior.

**Behavior after this PR**
- include_tts=true: API attempts to return both text + audio.
- include_tts=false: API returns text only.
- TTS provider error: API still returns text (no hard failure due to TTS path).

**Why this matters**
- Improves reliability and user experience for story generation flows.
- Preserves backward compatibility for existing frontend integrations.
- Reduces production risk from third-party TTS outages or routing changes.

**Testing done**
- Live endpoint verification for all 3 APIs with include_tts=true.
- Confirmed successful text responses even when TTS path encounters provider errors.
- Confirmed audio responses include valid media type and base64 payload when available.

**Testing Example:**
**/ai/sample**("include_tts": true)
<img width="1920" height="1080" alt="TTS_ai_sample" src="https://github.com/user-attachments/assets/f4fd2b13-d8c8-425c-98cd-d74ce806bf35" />

**story/generate-rhyme**("include_tts": true)
<img width="1920" height="1080" alt="TTS_story_generate-rhyme" src="https://github.com/user-attachments/assets/4c4652e0-dfa4-4619-908f-9548c29857b0" />

**story/rewrite**("include_tts": true)
<img width="1920" height="1080" alt="TTS_story_rewrite" src="https://github.com/user-attachments/assets/d360287d-208c-4f33-85aa-2415d86ddce8" />
